### PR TITLE
fix(web): use hosts of environment for allowed hosts

### DIFF
--- a/infrastructure/_base.yml
+++ b/infrastructure/_base.yml
@@ -105,6 +105,9 @@ services:
     depends_on:
       poweruptime-backend:
         condition: service_healthy
+    environment:
+      - POWERUPTIME_HOST=${POWERUPTIME_HOST:?}
+      - DOMAIN_NAMES=${DOMAIN_NAMES}
     labels:
       traefik.enable: true
       traefik.http.services.poweruptime-web.loadbalancer.server.port: 4200

--- a/web/angular.json
+++ b/web/angular.json
@@ -62,9 +62,6 @@
             "index": "src/index.html",
             "outputMode": "server",
             "outputPath": "dist/poweruptime-web",
-            "security": {
-              "allowedHosts": ["127.0.0.1", "127.0.0.1:4200", "localhost:4200", "localhost"]
-            },
             "server": "src/main.server.ts",
             "ssr": {
               "entry": "src/server/server.ts"

--- a/web/compose.yml
+++ b/web/compose.yml
@@ -13,6 +13,10 @@ services:
       - '4200:4200'
     networks:
       - poweruptime-local-dev-network
+# localhost:4200 gets added automatically
+#    environment:
+#      - POWERUPTIME_HOST=localhost:4200
+#      - DOMAIN_NAMES="Host(`status1.abc.xyz`) || Host(`status2.abc.xzy`)"
 
 networks:
   poweruptime-local-dev-network:

--- a/web/src/server/server.ts
+++ b/web/src/server/server.ts
@@ -14,6 +14,25 @@ import {BACKEND_API_URL, environment} from '@app/util';
 
 import og from './og';
 
+const allowedHostsSet = new Set(['127.0.0.1', '127.0.0.1:4200', 'localhost:4200', 'localhost']);
+
+const PU_HOST = process.env['POWERUPTIME_HOST'];
+const DOMAIN_NAMES = process.env['DOMAIN_NAMES'];
+
+if (PU_HOST) {
+  allowedHostsSet.add(PU_HOST);
+}
+
+if (DOMAIN_NAMES) {
+  [...DOMAIN_NAMES.matchAll(/Host\(`([^`]+)`\)/g)]
+    .map((match) => match[1])
+    .forEach((host) => allowedHostsSet.add(host));
+}
+
+const allowedHosts = [...allowedHostsSet];
+
+console.log(`Allowed hosts: ${allowedHosts.map((it) => `"${it}"`).join(', ')}`);
+
 export async function app() {
   const server = express();
 
@@ -57,7 +76,7 @@ export async function app() {
 
   server.all(/.*/, async (req: Request, res: Response) => {
     try {
-      const engine = new AngularNodeAppEngine();
+      const engine = new AngularNodeAppEngine({allowedHosts});
       const response = await engine.handle(req, {server: 'express'});
 
       if (response) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Server now dynamically configures allowed hosts and domain names through environment variables instead of hardcoded build settings, enabling greater flexibility when deploying to different environments.

* **Infrastructure**
  * Updated service configuration to explicitly manage host and domain environment variables for improved deployment control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poweruptime/poweruptime/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->